### PR TITLE
Add offline setup script and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Agent Development Guidelines
+
+This repository does not ship agent instructions. The following rules are provided to help future automation contribute effectively.
+
+## Commit Message Standards
+- Use **Conventional Commits** format.
+- Example: `feat: add support for custom tensor`.
+- Keep messages concise (50 characters max for the subject line).
+- Use the body section to explain *why* the change was made.
+
+## Commit Sequencing Guidelines
+- Keep commits atomic and logically grouped.
+- New tests should be added in the same commit as the feature they verify.
+- Refactors must not mix functional changes with style fixes.
+
+## Pull Request Standards
+- Title should summarize the change using sentence case.
+- Description must include: Summary, Testing, and Future Work sections.
+- Link to relevant issues when available.
+- PRs are ready for review only when all tests pass locally.
+
+## Code Housekeeping
+- Run `make setup-lint` before committing to ensure lint configuration is up to date.
+- Use `lintrunner` to run lint checks locally: `make lint`.
+- Remove dead code and unused dependencies when discovered.
+- Security scans should be run periodically using `lintrunner` security hooks.
+
+## Architecture and Design
+- Major architectural changes should be documented using ADRs in `docs/adr/`.
+- Prefer modular design with clear boundaries between `torch`, `caffe2`, `torchgen`, and other subpackages.
+- Public APIs must remain backward compatible unless a major version bump is planned.
+
+## Pre-commit Checks
+- Ensure `lintrunner init` has been executed to fetch linter binaries.
+- Run `make lint` and `python test/run_test.py --subset=quick` before committing.
+- Commit messages are validated with the Conventional Commits spec.
+
+## Version Management
+- Follow **SemVer**. Increment:
+  - **MAJOR** for API incompatible changes.
+  - **MINOR** for backward compatible functionality.
+  - **PATCH** for bug fixes and documentation only changes.
+- Tag releases as `v<major>.<minor>.<patch>`.
+
+## CHANGELOG Maintenance
+- Update `CHANGELOG.md` under an `Unreleased` section for every PR that affects users.
+- Categorize entries as Added, Changed, Deprecated, Removed, Fixed, or Security.
+- Reference PR numbers and dates when releasing.
+
+## Testing Standards
+- Prefer `python test/run_test.py` for the full suite.
+- Quick checks can use `python test/run_test.py --subset=quick`.
+- Tests should be named `test_*` and placed in the `test/` directory.
+- Maintain high coverage for new code paths.
+
+## Documentation Standards
+- Public functions and classes require docstrings formatted for Sphinx.
+- Update `README.md` or relevant docs when user-facing behavior changes.
+- Examples included in docs must execute successfully under `make html`.
+

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ conda install cmake ninja
 pip install -r requirements.txt
 ```
 
+# Optional: prepare an offline-ready development environment
+./setup-dev.sh
+
 **On Linux**
 
 ```bash

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+# PyTorch development environment setup
+# This script installs all dependencies and prepares caches for offline work.
+# Run once with internet connectivity.
+
+# Detect OS (supports Debian/Ubuntu)
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        ubuntu|debian)
+            pkg_manager="apt-get"
+            sudo $pkg_manager update
+            sudo DEBIAN_FRONTEND=noninteractive $pkg_manager install -y --no-install-recommends \
+                build-essential ca-certificates ccache cmake curl git \
+                libjpeg-dev libpng-dev ninja-build python3-venv python3-pip \
+                nodejs yarn doxygen
+            ;;
+        *)
+            echo "Unsupported OS: $ID" >&2
+            exit 1
+            ;;
+    esac
+else
+    echo "Cannot determine operating system" >&2
+    exit 1
+fi
+
+# Create Python virtual environment
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+python -m pip install --upgrade pip
+
+CACHE_DIR="$(pwd)/.offline/pip"
+mkdir -p "$CACHE_DIR"
+
+# Download Python dependencies
+pip download -r requirements.txt -d "$CACHE_DIR"
+pip download -r docs/requirements.txt -d "$CACHE_DIR"
+pip download lintrunner mkl-static mkl-include -d "$CACHE_DIR"
+
+# Install dependencies from local cache
+pip install --no-index --find-links "$CACHE_DIR" -r requirements.txt
+pip install --no-index --find-links "$CACHE_DIR" -r docs/requirements.txt
+pip install --no-index --find-links "$CACHE_DIR" lintrunner mkl-static mkl-include
+
+# Initialize lintrunner to download linter binaries
+lintrunner init
+
+# Synchronize and update git submodules
+git submodule sync
+git submodule update --init --recursive
+
+# Add common environment variables to .bashrc if missing
+grep -qxF 'export CMAKE_PREFIX_PATH=/usr/local' ~/.bashrc || \
+    echo 'export CMAKE_PREFIX_PATH=/usr/local' >> ~/.bashrc
+grep -qxF 'export LDFLAGS="-L/usr/local/cuda/lib64/ $LDFLAGS"' ~/.bashrc || \
+    echo 'export LDFLAGS="-L/usr/local/cuda/lib64/ $LDFLAGS"' >> ~/.bashrc
+
+# Verification
+python -m pip --version
+cmake --version
+ninja --version
+lintrunner --version
+
+cat <<'INFO'
+Setup complete.
+Activate the virtual environment with 'source .venv/bin/activate' before development.
+INFO


### PR DESCRIPTION
## Summary
- add `setup-dev.sh` for building an offline-ready dev environment
- document the agent workflow and contribution standards in `AGENTS.md`
- mention the setup script in the README

## Testing
- `make lint` *(fails: FLAKE8 failure)*
- `python test/run_test.py --subset=quick` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684947940b68832b9c6e1d194d6acb75